### PR TITLE
Add processor to remove style rule errors from files formatted with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Example config:
 
 	{
 		"branches": {
-			"default": ["downgrade-unmodified-lines", "filter-when-format", "enforce"],
+			"default": ["downgrade-unmodified-lines", "enforce"],
 			"master": ["filter-parsing-errors"],
-			"my/topic-branch": ["filter-parsing-errors"]
+			"my/topic-branch": ["filter-when-format"]
 		},
 		"processors": {
 			"downgrade-unmodified-lines": {
@@ -64,7 +64,11 @@ Example config:
 		}
 	}
 
-With the above configuration, the linting process will report only JavaScript parsing errors when running on a git branch called `master` or `my/topic-branch`. For other branches, `eslines` will report any `max-len` or `no-unused-vars` break, plus any error in lines modified within the current branch (provided that `no-unused-vars` is defined as an error in ESLint). For files that contain the `@format` tag, it will completely remove any errors or warnings reported by the `indent` rule, but will keep them in other files that don't contain the tag.
+With the above configuration, the linting process will report only JavaScript parsing errors when running on a git branch called `master`.
+
+On the `my/topic-branch` branch, `eslines` will completely remove any breaks reported by the `indent` rule in files that contain the `@format` tag. It will keep them intact in other files that don't contain the tag.
+
+For other branches, `eslines` will report any `max-len` or `no-unused-vars` break, plus any error in lines modified within the current branch (provided that `no-unused-vars` is defined as an error in ESLint).
 
 * **branches**: tell `eslines` which processors to use by default and which ones to use for particular branches. If none is set, it'll use `downgrade-unmodified-lines`.
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ If you rather use node-like pipes, check the [eslint-eslines](https://github.com
 
 ## Config file
 
-`eslines` reads its configuration from a file named `.eslines.json` placed in the root of your git repository. Out of the box, it comes with three ways of post-processing an ESLint report - we call them *processors*: `downgrade-unmodified-lines`, `filter-parsing-errors`, `enforce`.
+`eslines` reads its configuration from a file named `.eslines.json` placed in the root of your git repository. Out of the box, it comes with four ways of post-processing an ESLint report - we call them *processors*: `downgrade-unmodified-lines`, `filter-parsing-errors`, `filter-when-format`, `enforce`.
 
 Example config:
 
 	{
 		"branches": {
-			"default": ["downgrade-unmodified-lines", "enforce"],
+			"default": ["downgrade-unmodified-lines", "filter-when-format", "enforce"],
 			"master": ["filter-parsing-errors"],
 			"my/topic-branch": ["filter-parsing-errors"]
 		},
@@ -55,13 +55,16 @@ Example config:
 				"remote": "origin/master",
 				"rulesNotToDowngrade": ["no-unused-vars"]
 			},
+			"filter-when-format": {
+				"rulesToIgnore": ["indent"]
+			},
 			"enforce": {
 				"rules": ["max-len"]
 			}
 		}
 	}
 
-With the above configuration, the linting process will report only JavaScript parsing errors when running on a git branch called `master` or `my/topic-branch`. For other branches, `eslines` will report any `max-len` or `no-unused-vars` break, plus any error in lines modified within the current branch (provided that `no-unused-vars` is defined as an error in ESLint).
+With the above configuration, the linting process will report only JavaScript parsing errors when running on a git branch called `master` or `my/topic-branch`. For other branches, `eslines` will report any `max-len` or `no-unused-vars` break, plus any error in lines modified within the current branch (provided that `no-unused-vars` is defined as an error in ESLint). For files that contain the `@format` tag, it will completely remove any errors or warnings reported by the `indent` rule, but will keep them in other files that don't contain the tag.
 
 * **branches**: tell `eslines` which processors to use by default and which ones to use for particular branches. If none is set, it'll use `downgrade-unmodified-lines`.
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test-enforce": "./node_modules/.bin/tape tests/test-enforce.js | ./node_modules/.bin/faucet",
     "test-downgrade-unmodified-lines": "./node_modules/.bin/tape tests/test-downgrade-unmodified-lines.js | ./node_modules/.bin/faucet",
     "test-exit-codes": "./node_modules/.bin/tape tests/test-exit-codes.js | ./node_modules/.bin/faucet",
-    "test-filter-parsing-errors": "./node_modules/.bin/tape tests/test-filter-parsing-errors.js | ./node_modules/.bin/faucet"
+    "test-filter-parsing-errors": "./node_modules/.bin/tape tests/test-filter-parsing-errors.js | ./node_modules/.bin/faucet",
+    "test-filter-when-format": "./node_modules/.bin/tape tests/test-filter-when-format.js | ./node_modules/.bin/faucet"
   },
   "dependencies": {
     "jest-docblock": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test-filter-parsing-errors": "./node_modules/.bin/tape tests/test-filter-parsing-errors.js | ./node_modules/.bin/faucet"
   },
   "dependencies": {
+    "jest-docblock": "20.0.3",
     "optionator": "0.8.1"
   },
   "devDependencies": {

--- a/src/lib/filter-when-format.js
+++ b/src/lib/filter-when-format.js
@@ -1,0 +1,44 @@
+const docblock = require( 'jest-docblock' );
+
+function fileHasFormatPragma( file ) {
+	return file.source && 'format' in docblock.parse( file.source );
+}
+
+// If the file has the @format pragma at the beginning, it means it was formatted with
+// Prettier and that specified ESlint style rules should be ignored -- they sometimes
+// have a different opinion about the formatting, but Prettier is the authority.
+module.exports = function filterWhenFormat( report, rulesToIgnore ) {
+	if ( ! Array.isArray( rulesToIgnore ) || rulesToIgnore.length === 0 ) {
+		return report;
+	}
+
+	const filtered = report.map( file => {
+		if ( ! fileHasFormatPragma( file ) ) {
+			return file;
+		}
+
+		let { warningCount, errorCount } = file;
+
+		const messages = file.messages.filter( message => {
+			const shouldRemove = rulesToIgnore.includes( message.ruleId );
+
+			if ( shouldRemove ) {
+				if ( message.severity === 1 ) {
+					warningCount--;
+				} else if ( message.severity === 2 ) {
+					errorCount--;
+				}
+			}
+
+			return ! shouldRemove;
+		} );
+
+		if ( messages.length === 0 ) {
+			return null;
+		}
+
+		return Object.assign( {}, file, { messages, warningCount, errorCount } );
+	} );
+
+	return filtered.filter( Boolean ); // remove the null entries
+};

--- a/src/lib/filter-when-format.js
+++ b/src/lib/filter-when-format.js
@@ -4,9 +4,6 @@ function fileHasFormatPragma( file ) {
 	return file.source && 'format' in docblock.parse( file.source );
 }
 
-// If the file has the @format pragma at the beginning, it means it was formatted with
-// Prettier and that specified ESlint style rules should be ignored -- they sometimes
-// have a different opinion about the formatting, but Prettier is the authority.
 module.exports = function filterWhenFormat( report, rulesToIgnore ) {
 	if ( ! Array.isArray( rulesToIgnore ) || rulesToIgnore.length === 0 ) {
 		return report;

--- a/src/processors/README.md
+++ b/src/processors/README.md
@@ -42,7 +42,9 @@ No config needed.
 
 ### filter-when-format
 
-`filter-when-format` will check if the first docblock comment of the file contains a `@format` tag. That means that the file was formatted with Prettier or a similar tool and that formatting-only rules (like `indent`) can be ignored for this file. The motivation for this processor is that ESLint rules sometimes have a different opinion about formatting than Prettier, so we want to conditionally turn them of and treat Prettier as the authority.
+`filter-when-format` will remove any break for the rules indicated if the first file docblock comment contains a `@format` tag, so these rule breaks will be filtered and won't be passed to the next processor or final report.
+
+The use case for this processor is when trying to use a tool other than `ESLint` to format the code. Sometimes, `ESLint` has a different opinion about the final formatting, so we need to conditionally turn some rules off if the file is already formatted (like the `indent` rule).
 
 Config:
 

--- a/src/processors/README.md
+++ b/src/processors/README.md
@@ -40,6 +40,20 @@ Example:
 
 No config needed.
 
+### filter-when-format
+
+`filter-when-format` will check if the first docblock comment of the file contains a `@format` tag. That means that the file was formatted with Prettier or a similar tool and that formatting-only rules (like `indent`) can be ignored for this file. The motivation for this processor is that ESLint rules sometimes have a different opinion about formatting than Prettier, so we want to conditionally turn them of and treat Prettier as the authority.
+
+Config:
+
+* `rulesToIgnore`: array of ESLint rule ids that should be removed from the report if the `@format` tag is present in the checked file.
+
+Example:
+
+    "filter-when-format": {
+        "rulesToIgnore": ["indent"]
+    }
+
 ### enforce
 
 `enforce` transforms `warnings` into `errors` for a subset of rules.
@@ -50,6 +64,6 @@ Config options:
 
 Example config:
 
-    enforce": {
+    "enforce": {
         "rules": ["max-len"]
     }

--- a/src/processors/filter-when-format.js
+++ b/src/processors/filter-when-format.js
@@ -1,0 +1,10 @@
+const fs = require( 'fs' );
+const filterWhenFormat = require( '../lib/filter-when-format' );
+
+const config = JSON.parse( fs.readFileSync( '.eslines.json', 'utf-8' ) );
+
+module.exports = function( report ) {
+	const processorConfig = config.processors[ 'filter-when-format' ] || {};
+	const rulesToIgnore = processorConfig.rulesToIgnore || [];
+	return JSON.stringify( filterWhenFormat( report, rulesToIgnore ) );
+};

--- a/tests/fixtures/eslint-with-format.json
+++ b/tests/fixtures/eslint-with-format.json
@@ -1,0 +1,67 @@
+[
+  {
+    "filePath": "with-format.js",
+    "messages": [
+      {
+        "ruleId": "indent",
+        "severity": 2,
+        "message": "Expected indentation of 0 tabs but found 2 spaces.",
+        "line": 2,
+        "column": 3,
+        "nodeType": "VariableDeclaration",
+        "source": "  const x = 0;",
+        "fix": {
+          "range": [
+            15,
+            17
+          ],
+          "text": ""
+        }
+      },
+      {
+        "ruleId": "no-unused-vars",
+        "severity": 2,
+        "message": "'y' is assigned a value but never used.",
+        "line": 3,
+        "column": 7,
+        "nodeType": "Identifier",
+        "source": "const y = 2 * x;"
+      }
+    ],
+    "errorCount": 2,
+    "warningCount": 0,
+    "source": "/** @format */\n  const x = 0;\nconst y = 2 * x;\n"
+  },
+	{
+		"filePath": "without-format.js",
+		"messages": [
+			{
+				"ruleId": "indent",
+				"severity": 2,
+				"message": "Expected indentation of 0 tabs but found 2 spaces.",
+				"line": 1,
+				"column": 3,
+				"nodeType": "VariableDeclaration",
+				"source": "  const x = 0;",
+				"fix": {
+					"range": [
+						0,
+						2
+					],
+					"text": ""
+				}
+			},
+			{
+				"ruleId": "no-unused-vars",
+				"severity": 2,
+				"message": "'y' is assigned a value but never used.",
+				"line": 2,
+				"column": 7,
+				"nodeType": "Identifier",
+				"source": "const y = 2 * x;"
+			}
+		],
+		"errorCount": 2,
+		"warningCount": 0,
+		"source": "  const x = 0;\nconst y = 2 * x;\n"
+	}]

--- a/tests/test-filter-when-format.js
+++ b/tests/test-filter-when-format.js
@@ -1,0 +1,24 @@
+const test = require( 'tape' );
+const filterWhenFormat = require( '../src/lib/filter-when-format.js' );
+
+// fixtures
+const report = require( './fixtures/eslint-with-format.json' );
+
+test( 'filter-when-format - removes style errors from the report if @format is present', t => {
+	const newReport = filterWhenFormat( [ report[ 0 ] ], [ 'indent' ] );
+	t.equals( newReport.length, 1 );
+	t.equals( newReport[ 0 ].messages.length, 1 );
+	t.equals( newReport[ 0 ].messages[ 0 ].ruleId, 'no-unused-vars' );
+
+	t.end();
+} );
+
+test( 'filter-when-format - keeps style errors in the report if @format is not present', t => {
+	const newReport = filterWhenFormat( [ report[ 1 ] ], [ 'indent' ] );
+	t.equals( newReport.length, 1 );
+	t.equals( newReport[ 0 ].messages.length, 2 );
+	t.equals( newReport[ 0 ].messages[ 0 ].ruleId, 'indent' );
+	t.equals( newReport[ 0 ].messages[ 1 ].ruleId, 'no-unused-vars' );
+
+	t.end();
+} );


### PR DESCRIPTION
**Prettier formatting processor**
The `prettier-formatting` processor will read the `formattingRulesToIgnore` key from the config, which is an array of rule IDs.
    
If the file has a `@format` pragma, errors from these rules will be filtered out, as some ESlint rules are incompatible with how Prettier does things.
    
Your `.eslines.json` config is supposed to look like this:
```
{
  "rulesNotToDowngrade": ["no-unused-vars"],
  "formattingRulesToIgnore": ["indent"],
  "remote": "origin/master",
  "processors": {
    "default": "lines-modified,prettier-formatting",
    "master": "parsing-errors"
  }
}
```

**Support for processor pipeline**
Define multiple processors in your `.eslines.json` like this:
```
"processors": {
  "default": "lines-modified,prettier-formatting"
}
```
Then all these processors, separated by comma, will be run one after another, feeding the output of the previous one into the next.