### PR TITLE
Fix/not lines provided

### DIFF
--- a/src/lib/downgrade-unmodified-lines.js
+++ b/src/lib/downgrade-unmodified-lines.js
@@ -26,12 +26,20 @@ module.exports = function( report, lines, rulesNotToDowngrade ) {
 		return severity === 2;
 	};
 
+	const getLinesModifiedInFile = ( linesModified, file ) => {
+		if ( linesModified && linesModified.constructor === Object ) {
+			return linesModified[ file ] || [];
+		}
+		return [];
+	};
+
 	// errors in lines not modified will be downgraded to warnings
 	// except those rules set not to downgrade
 	newReport.forEach( file => {
+		const linesModifiedInFile = getLinesModifiedInFile( lines, file.filePath );
 		file.messages.forEach( message => {
 			if ( isMessageAnError( message.severity ) &&
-				! isLineModified( message.line, lines[ file.filePath ] ) &&
+				! isLineModified( message.line, linesModifiedInFile ) &&
 				! isRuleNotToDowngrade( message.ruleId, rulesNotToDowngrade ) ) {
 				message.severity = 1;
 				file.warningCount ++;

--- a/src/lib/downgrade-unmodified-lines.js
+++ b/src/lib/downgrade-unmodified-lines.js
@@ -3,11 +3,6 @@ module.exports = function( report, lines, rulesNotToDowngrade ) {
 	// to tweak and edit in place - as this function remains pure.
 	const newReport = JSON.parse( JSON.stringify( report ) );
 
-	// If lines is an empty object {} we should not filter the report.
-	if ( ( Object.keys( lines ).length === 0 ) && ( lines.constructor === Object ) ) {
-		return newReport;
-	}
-
 	const isRuleNotToDowngrade = ( ruleId, rules ) => {
 		if ( ! Array.isArray( rules ) ) {
 			return false;

--- a/tests/fixtures/eslint-only-rules.json
+++ b/tests/fixtures/eslint-only-rules.json
@@ -1,0 +1,497 @@
+[
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/auth/auth-code-button.jsx",
+        "messages": [
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 39,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar noticeStatus = 'is-info';"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 40,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar showDismiss = false;"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 41,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar message = ("
+            },
+            {
+                "ruleId": "semi",
+                "severity": 1,
+                "message": "Missing semicolon.",
+                "line": 67,
+                "column": 4,
+                "nodeType": "ExportDefaultDeclaration",
+                "source": "} )",
+                "fix": {
+                    "range": [
+                        1492,
+                        1492
+                    ],
+                    "text": ";"
+                }
+            }
+        ],
+        "errorCount": 0,
+        "warningCount": 4
+    },
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/auth/connect.jsx",
+        "messages": [
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 32 exceeds the maximum line length of 140.",
+                "line": 32,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t\t\t<NoticeAction href=\"https://developer.wordpress.com/apps/\">{ this.translate( 'Go to Developer Resources' ) }</NoticeAction>"
+            },
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 36 exceeds the maximum line length of 140.",
+                "line": 36,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t\t\t\t{ this.translate( 'Welcome to Calypso. Authorize the application with your WordPress.com credentials to get started.' ) }"
+            },
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 41 exceeds the maximum line length of 140.",
+                "line": 41,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t<a className=\"auth__help\" target=\"_blank\" title={ this.translate( 'Visit the Calypso GitHub repository for help' ) } href=\"https://github.com/Automattic/wp-calypso\">"
+            }
+        ],
+        "errorCount": 3,
+        "warningCount": 0
+    },
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/auth/controller.js",
+        "messages": [
+            {
+                "ruleId": "no-else-return",
+                "severity": 1,
+                "message": "Unexpected 'else' after 'return'.",
+                "line": 45,
+                "column": 11,
+                "nodeType": "BlockStatement",
+                "source": "\t\t\t} else {"
+            },
+            {
+                "ruleId": "no-else-return",
+                "severity": 1,
+                "message": "Unexpected 'else' after 'return'.",
+                "line": 53,
+                "column": 10,
+                "nodeType": "BlockStatement",
+                "source": "\t\t} else {"
+            },
+            {
+                "ruleId": "wpcalypso/jsx-classname-namespace",
+                "severity": 1,
+                "message": "className should follow CSS namespace guidelines (expected auth__ prefix)",
+                "line": 98,
+                "column": 10,
+                "nodeType": "JSXAttribute",
+                "source": "\t\t\t<Main className=\"auth\">"
+            }
+        ],
+        "errorCount": 0,
+        "warningCount": 3
+    },
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/auth/index.js",
+        "messages": [],
+        "errorCount": 0,
+        "warningCount": 0
+    },
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/auth/login.jsx",
+        "messages": [
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 43 exceeds the maximum line length of 140.",
+                "line": 43,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t<a href=\"#\" onClick={ this.props.onClickClose } className=\"auth__self-hosted-instructions-close\"><Gridicon icon=\"cross\" size={ 24 } /></a>"
+            },
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 46 exceeds the maximum line length of 140.",
+                "line": 46,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t<p>{ this.translate( 'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com' ) }</p>"
+            },
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 47 exceeds the maximum line length of 140.",
+                "line": 47,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t<p>{ this.translate( 'If you\\'d like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:' ) }</p>"
+            },
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 50 exceeds the maximum line length of 140.",
+                "line": 50,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t\t<li><strong>{ this.translate( 'Install the Jetpack plugin.' ) }</strong><br /><a href=\"http://jetpack.me/install/\">{ this.translate( 'Please follow these instructions to install Jetpack' ) }</a>.</li>"
+            },
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 52 exceeds the maximum line length of 140.",
+                "line": 52,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t\t<li>{ this.translate( 'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, and you can find your self-hosted site under the \"My Sites\" section.' ) }</li>"
+            },
+            {
+                "ruleId": "space-before-function-paren",
+                "severity": 1,
+                "message": "Unexpected space before function parentheses.",
+                "line": 120,
+                "column": 40,
+                "nodeType": "FunctionExpression",
+                "source": "\ttoggleSelfHostedInstructions: function () {",
+                "fix": {
+                    "range": [
+                        3718,
+                        3719
+                    ],
+                    "text": ""
+                }
+            },
+            {
+                "ruleId": "no-mixed-spaces-and-tabs",
+                "severity": 1,
+                "message": "Mixed spaces and tabs.",
+                "line": 121,
+                "column": 2,
+                "nodeType": "Program",
+                "source": "\t    var isShowing = !this.state.showInstructions;"
+            },
+            {
+                "ruleId": "indent",
+                "severity": 1,
+                "message": "Expected indentation of 2 tab characters but found 1.",
+                "line": 121,
+                "column": 6,
+                "nodeType": "VariableDeclaration",
+                "source": "\t    var isShowing = !this.state.showInstructions;",
+                "fix": {
+                    "range": [
+                        3729,
+                        3729
+                    ],
+                    "text": "\t"
+                }
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 121,
+                "column": 6,
+                "nodeType": "VariableDeclaration",
+                "source": "\t    var isShowing = !this.state.showInstructions;"
+            },
+            {
+                "ruleId": "space-unary-ops",
+                "severity": 1,
+                "message": "Unary operator '!' must be followed by whitespace.",
+                "line": 121,
+                "column": 22,
+                "nodeType": "UnaryExpression",
+                "source": "\t    var isShowing = !this.state.showInstructions;",
+                "fix": {
+                    "range": [
+                        3746,
+                        3746
+                    ],
+                    "text": " "
+                }
+            },
+            {
+                "ruleId": "no-mixed-spaces-and-tabs",
+                "severity": 1,
+                "message": "Mixed spaces and tabs.",
+                "line": 122,
+                "column": 2,
+                "nodeType": "Program",
+                "source": "\t    this.setState( { showInstructions: isShowing } );"
+            },
+            {
+                "ruleId": "indent",
+                "severity": 1,
+                "message": "Expected indentation of 2 tab characters but found 1.",
+                "line": 122,
+                "column": 6,
+                "nodeType": "ExpressionStatement",
+                "source": "\t    this.setState( { showInstructions: isShowing } );",
+                "fix": {
+                    "range": [
+                        3780,
+                        3780
+                    ],
+                    "text": "\t"
+                }
+            },
+            {
+                "ruleId": "wpcalypso/jsx-classname-namespace",
+                "severity": 1,
+                "message": "className should follow CSS namespace guidelines (expected auth__ prefix)",
+                "line": 129,
+                "column": 10,
+                "nodeType": "JSXAttribute",
+                "source": "\t\t\t<Main className=\"auth\">"
+            },
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 177 exceeds the maximum line length of 140.",
+                "line": 177,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\t\t\t<a className=\"auth__help\" target=\"_blank\" title={ this.translate( 'Visit the WordPress.com support site for help' ) } href=\"https://en.support.wordpress.com/\">"
+            }
+        ],
+        "errorCount": 6,
+        "warningCount": 8
+    },
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/auth/test/login.jsx",
+        "messages": [
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 43,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar submit = TestUtils.findRenderedDOMComponentWithTag( page, 'button' );"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 67,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar submit = TestUtils.findRenderedDOMComponentWithTag( page, 'form' );"
+            }
+        ],
+        "errorCount": 0,
+        "warningCount": 2
+    },
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/components/accordion/index.jsx",
+        "messages": [
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 4,
+                "column": 1,
+                "nodeType": "VariableDeclaration",
+                "source": "var React = require( 'react' ),"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 35,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar isExpanded = ! this.state.isExpanded;"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 63,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar classes = classNames( 'accordion__header', {"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 80,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar classes = classNames( 'accordion', this.props.className, {"
+            }
+        ],
+        "errorCount": 0,
+        "warningCount": 4
+    },
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/components/accordion/section.jsx",
+        "messages": [
+            {
+                "ruleId": "space-in-parens",
+                "severity": 1,
+                "message": "There must be a space inside this paren.",
+                "line": 7,
+                "column": 33,
+                "nodeType": "Program",
+                "source": "export default React.createClass({",
+                "fix": {
+                    "range": [
+                        131,
+                        131
+                    ],
+                    "text": " "
+                }
+            },
+            {
+                "ruleId": "space-before-blocks",
+                "severity": 1,
+                "message": "Missing space before opening brace.",
+                "line": 8,
+                "column": 10,
+                "nodeType": "BlockStatement",
+                "source": "\trender(){",
+                "fix": {
+                    "range": [
+                        142,
+                        142
+                    ],
+                    "text": " "
+                }
+            },
+            {
+                "ruleId": "keyword-spacing",
+                "severity": 1,
+                "message": "Expected space(s) after \"return\".",
+                "line": 9,
+                "column": 3,
+                "source": "\t\treturn(",
+                "fix": {
+                    "range": [
+                        152,
+                        152
+                    ],
+                    "text": " "
+                }
+            }
+        ],
+        "errorCount": 0,
+        "warningCount": 3
+    },
+    {
+        "filePath": "/home/vagrant/wp-calypso/client/components/accordion/test/index.jsx",
+        "messages": [
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 4,
+                "column": 1,
+                "nodeType": "VariableDeclaration",
+                "source": "var expect = require( 'chai' ).expect,"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 12,
+                "column": 1,
+                "nodeType": "VariableDeclaration",
+                "source": "var Accordion = require( '../' );"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 23,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar tree = TestUtils.renderIntoDocument( <Accordion title=\"Section\">Content</Accordion> ),"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 36,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar tree = TestUtils.renderIntoDocument( <Accordion title=\"Section\" icon=\"time\">Content</Accordion> ),"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 44,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar tree = TestUtils.renderIntoDocument( <Accordion title=\"Section\" subtitle=\"Subtitle\">Content</Accordion> ),"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 52,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar tree = TestUtils.renderIntoDocument( <Accordion title=\"Section\">Content</Accordion> );"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 60,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar tree = TestUtils.renderIntoDocument( <Accordion title=\"Section\" onToggle={ finishTest }>Content</Accordion> );"
+            },
+            {
+                "ruleId": "max-len",
+                "severity": 2,
+                "message": "Line 75 exceeds the maximum line length of 140.",
+                "line": 75,
+                "column": 1,
+                "nodeType": "Program",
+                "source": "\t\tvar tree = TestUtils.renderIntoDocument( <Accordion initialExpanded={ true } title=\"Section\" onToggle={ finishTest }>Content</Accordion> );"
+            },
+            {
+                "ruleId": "no-var",
+                "severity": 1,
+                "message": "Unexpected var, use let or const instead.",
+                "line": 75,
+                "column": 3,
+                "nodeType": "VariableDeclaration",
+                "source": "\t\tvar tree = TestUtils.renderIntoDocument( <Accordion initialExpanded={ true } title=\"Section\" onToggle={ finishTest }>Content</Accordion> );"
+            }
+        ],
+        "errorCount": 1,
+        "warningCount": 8
+    }
+]

--- a/tests/test-downgrade-unmodified-lines.js
+++ b/tests/test-downgrade-unmodified-lines.js
@@ -5,6 +5,7 @@ const downgradeUnmodifiedLines = require( '../src/lib/downgrade-unmodified-lines
 const baseReport = require( './fixtures/eslint.json' );
 const linesModifiedReport = require( './fixtures/eslint-lines-modified.json' );
 const linesAndRulesReport = require( './fixtures/eslint-lines-and-rules.json' );
+const onlyRulesReport = require( './fixtures/eslint-only-rules.json' );
 const lines = require( './fixtures/lines.json' );
 
 test( 'downgrade-unmodified-lines - empty array if original report is empty', t => {
@@ -16,10 +17,71 @@ test( 'downgrade-unmodified-lines - empty array if original report is empty', t 
 	t.end();
 } );
 
-test( 'downgrade-unmodified-lines - same report if lines parameter is empty', t => {
-	const newReport = downgradeUnmodifiedLines( baseReport, {} );
+test( 'downgrade-unmodified-lines - all rules as warnings if lines parameter is empty, except those not to downgrade', t => { // eslint-disable-line max-len
+	const newReport = downgradeUnmodifiedLines( baseReport, {}, [ 'max-len' ] );
 
-	t.equals( JSON.stringify( newReport ), JSON.stringify( baseReport ) );
+	// t.equals( JSON.stringify( newReport ), JSON.stringify( downgradedReport ) );
+	t.equals( newReport[ 0 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 0 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 0 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 0 ].messages[ 3 ].severity, 1 );
+	t.equals( newReport[ 0 ].warningCount, onlyRulesReport[ 0 ].warningCount );
+	t.equals( newReport[ 0 ].errorCount, onlyRulesReport[ 0 ].errorCount );
+	t.equals( newReport[ 1 ].messages[ 0 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 1 ].messages[ 1 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 1 ].messages[ 2 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 1 ].warningCount, onlyRulesReport[ 1 ].warningCount );
+	t.equals( newReport[ 1 ].errorCount, onlyRulesReport[ 1 ].errorCount );
+	t.equals( newReport[ 2 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 2 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 2 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 2 ].warningCount, onlyRulesReport[ 2 ].warningCount );
+	t.equals( newReport[ 2 ].errorCount, onlyRulesReport[ 2 ].errorCount );
+	t.equals( newReport[ 3 ].messages.length, 0 );
+	t.equals( newReport[ 3 ].warningCount, onlyRulesReport[ 3 ].warningCount );
+	t.equals( newReport[ 3 ].errorCount, onlyRulesReport[ 3 ].errorCount );
+	t.equals( newReport[ 4 ].messages[ 0 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 1 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 2 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 3 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 4 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 5 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 6 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 7 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 8 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 9 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 10 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 11 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 12 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 13 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].warningCount, onlyRulesReport[ 4 ].warningCount );
+	t.equals( newReport[ 4 ].errorCount, onlyRulesReport[ 4 ].errorCount );
+	t.equals( newReport[ 5 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 5 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 5 ].warningCount, onlyRulesReport[ 5 ].warningCount );
+	t.equals( newReport[ 5 ].errorCount, onlyRulesReport[ 5 ].errorCount );
+	t.equals( newReport[ 6 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 6 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 6 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 6 ].messages[ 3 ].severity, 1 );
+	t.equals( newReport[ 6 ].warningCount, onlyRulesReport[ 6 ].warningCount );
+	t.equals( newReport[ 6 ].errorCount, onlyRulesReport[ 6 ].errorCount );
+	t.equals( newReport[ 7 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 7 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 7 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 7 ].warningCount, onlyRulesReport[ 7 ].warningCount );
+	t.equals( newReport[ 7 ].errorCount, onlyRulesReport[ 7 ].errorCount );
+	t.equals( newReport[ 8 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 3 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 4 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 5 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 6 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 7 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 8 ].messages[ 8 ].severity, 1 );
+	t.equals( newReport[ 8 ].warningCount, onlyRulesReport[ 8 ].warningCount );
+	t.equals( newReport[ 8 ].errorCount, onlyRulesReport[ 8 ].errorCount );
 	t.end();
 } );
 

--- a/tests/test-downgrade-unmodified-lines.js
+++ b/tests/test-downgrade-unmodified-lines.js
@@ -85,6 +85,74 @@ test( 'downgrade-unmodified-lines - all rules as warnings if lines parameter is 
 	t.end();
 } );
 
+test( 'downgrade-unmodified-lines - all rules as warnings if lines parameter is not an object, except those not to downgrade', t => { // eslint-disable-line max-len
+	const newReport = downgradeUnmodifiedLines( baseReport, undefined, [ 'max-len' ] );
+
+	// t.equals( JSON.stringify( newReport ), JSON.stringify( downgradedReport ) );
+	t.equals( newReport[ 0 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 0 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 0 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 0 ].messages[ 3 ].severity, 1 );
+	t.equals( newReport[ 0 ].warningCount, onlyRulesReport[ 0 ].warningCount );
+	t.equals( newReport[ 0 ].errorCount, onlyRulesReport[ 0 ].errorCount );
+	t.equals( newReport[ 1 ].messages[ 0 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 1 ].messages[ 1 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 1 ].messages[ 2 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 1 ].warningCount, onlyRulesReport[ 1 ].warningCount );
+	t.equals( newReport[ 1 ].errorCount, onlyRulesReport[ 1 ].errorCount );
+	t.equals( newReport[ 2 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 2 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 2 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 2 ].warningCount, onlyRulesReport[ 2 ].warningCount );
+	t.equals( newReport[ 2 ].errorCount, onlyRulesReport[ 2 ].errorCount );
+	t.equals( newReport[ 3 ].messages.length, 0 );
+	t.equals( newReport[ 3 ].warningCount, onlyRulesReport[ 3 ].warningCount );
+	t.equals( newReport[ 3 ].errorCount, onlyRulesReport[ 3 ].errorCount );
+	t.equals( newReport[ 4 ].messages[ 0 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 1 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 2 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 3 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 4 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].messages[ 5 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 6 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 7 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 8 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 9 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 10 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 11 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 12 ].severity, 1 );
+	t.equals( newReport[ 4 ].messages[ 13 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 4 ].warningCount, onlyRulesReport[ 4 ].warningCount );
+	t.equals( newReport[ 4 ].errorCount, onlyRulesReport[ 4 ].errorCount );
+	t.equals( newReport[ 5 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 5 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 5 ].warningCount, onlyRulesReport[ 5 ].warningCount );
+	t.equals( newReport[ 5 ].errorCount, onlyRulesReport[ 5 ].errorCount );
+	t.equals( newReport[ 6 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 6 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 6 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 6 ].messages[ 3 ].severity, 1 );
+	t.equals( newReport[ 6 ].warningCount, onlyRulesReport[ 6 ].warningCount );
+	t.equals( newReport[ 6 ].errorCount, onlyRulesReport[ 6 ].errorCount );
+	t.equals( newReport[ 7 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 7 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 7 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 7 ].warningCount, onlyRulesReport[ 7 ].warningCount );
+	t.equals( newReport[ 7 ].errorCount, onlyRulesReport[ 7 ].errorCount );
+	t.equals( newReport[ 8 ].messages[ 0 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 1 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 2 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 3 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 4 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 5 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 6 ].severity, 1 );
+	t.equals( newReport[ 8 ].messages[ 7 ].severity, 2, 'max-len rule not to donwgrade' );
+	t.equals( newReport[ 8 ].messages[ 8 ].severity, 1 );
+	t.equals( newReport[ 8 ].warningCount, onlyRulesReport[ 8 ].warningCount );
+	t.equals( newReport[ 8 ].errorCount, onlyRulesReport[ 8 ].errorCount );
+	t.end();
+} );
+
 test( 'downgrade-unmodified-lines - errors in files&lines not modified downgraded to warnings', t => { // eslint-disable-line max-len
 	const newReport = downgradeUnmodifiedLines( baseReport, lines );
 


### PR DESCRIPTION
Fixed `downgrade-unmodified-lines` processor: when there are no lines modified, the report should still downgrade all rules except those not to downgrade.