### PR TITLE
Upgrade to eslint 6.x and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 ## 2020-05-19 v2.0.0
 [v1.1.0...v2.0.0](https://github.com/Automattic/eslines/compare/v1.1.0...v2.0.0)
 
-#### Warning: this release breaks backward compatibility!
+- Bump dev & prod dependencies to the latest versions.
 
-* Update eslint to v6.x and above.
-* Bump dev & prod dependencies to latest versions.
+### Breaking changes
 
+- eslines now requires a peer dependency of ESLint 6 or above. [#20](https://github.com/Automattic/eslines/pull/20)
 
 ## 2017-09-05 v1.1.0
 [v1.0.0...v1.1.0](https://github.com/Automattic/eslines/compare/v1.0.0...v1.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
 
 ## Next version
-[v1.1.0...master](https://github.com/Automattic/eslines/compare/v1.1.0...master)
+[v2.0.0...master](https://github.com/Automattic/eslines/compare/v2.0.0...master)
 
+## 2020-05-19 v2.0.0
+[v1.1.0...v2.0.0](https://github.com/Automattic/eslines/compare/v1.1.0...v2.0.0)
+
+#### Warning: this release breaks backward compatibility!
+
+* Update eslint to v6.x and above.
 * Bump dev & prod dependencies to latest versions.
+
 
 ## 2017-09-05 v1.1.0
 [v1.0.0...v1.1.0](https://github.com/Automattic/eslines/compare/v1.0.0...v1.1.0)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "tape": "4.6.0",
     "faucet": "0.0.1",
-    "eslint": "4.6.1",
+    "eslint": "7.0.0",
     "eslint-config-wpcalypso": "1.0.0",
     "eslint-plugin-wpcalypso": "4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "babel-eslint": "10.1.0",
-    "eslint": ">=6.0.0",
+    "eslint": "^7.0.0",
     "eslint-config-wpcalypso": "5.0.0",
     "eslint-plugin-jsdoc": "25.4.1",
     "eslint-plugin-wpcalypso": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslines",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Utility to process ESLint JSON reports",
   "keywords": [
     "eslint"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "tape": "4.6.0",
     "faucet": "0.0.1",
-    "eslint": "7.0.0",
+    "eslint": ">=6.0.0",
     "eslint-config-wpcalypso": "1.0.0",
     "eslint-plugin-wpcalypso": "4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslines",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Utility to process ESLint JSON reports",
   "keywords": [
     "eslint"
@@ -38,5 +38,8 @@
     "eslint-plugin-wpcalypso": "4.1.0",
     "faucet": "0.0.1",
     "tape": "5.0.0"
+  },
+  "peerDependencies": {
+    "eslint": ">=6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "tape": "4.6.0",
     "faucet": "0.0.1",
-    "eslint": ">=6.0.0",
+    "eslint": "7.0.0",
     "eslint-config-wpcalypso": "1.0.0",
     "eslint-plugin-wpcalypso": "4.0.0"
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -33,7 +33,7 @@ module.exports = function( report, options ) {
 			if ( format.indexOf( '/' ) > -1 ) {
 				formatterPath = path.resolve( process.cwd(), format );
 			} else {
-				formatterPath = 'eslint/lib/formatters/' + format;
+				formatterPath = 'eslint/lib/cli-engine/formatters/' + format;
 			}
 
 			try {


### PR DESCRIPTION
Starting with eslint 6.x, `formatters` have been moved from `eslint/lib/formatters` into `eslint/lib/cli-engine/formatters`.

This fix will allow us to finally update all of our repositories to eslint 6.x or 7.x, whereas now we are stuck to 5.x.

Steps to test:

You can reproduce by using a repo that has this package as dependency.
By running `eslint -f json . | eslines` on a clone of that repo, you should get an error like the following:

```
node_modules/eslines/src/cli.js:44
				throw ex;
				^

Error: Problem loading formatter: eslint/lib/formatters/stylish
Error: Cannot find module 'eslint/lib/formatters/stylish'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
[CUT]
```

To see it fixed:

- Pull down this PR in a separate directory, say `~/eslines`.
- `cd ~/eslines` (or whatever your dir is)
- `npm pack` => will create `eslines-1.2.0.tgz`
- Go back to your "broken" repo and `npm I ~/eslines/eslines-1.2.0.tgz`

Tests should now be successful.

** Notes

Bumping the package version to 1.2.0 so anyone that is pinned to 1.1.0 won't break.