### PR TITLE
Update deps to latest versions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  root: true,
-  "extends": "wpcalypso",
-  "env": {
-    "node": true
-  }
+	root: true,
+	'extends': 'wpcalypso',
+	env: {
+		node: true,
+	},
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	root: true,
-	'extends': 'wpcalypso',
+	extends: 'wpcalypso',
 	env: {
 		node: true,
 	},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next version
 [v1.1.0...master](https://github.com/Automattic/eslines/compare/v1.1.0...master)
 
-* Bump eslint-config-wpcalypso, eslint-plugin-wpcalypso, and ESLint versions.
+* Bump dev & prod dependencies to latest versions.
 
 ## 2017-09-05 v1.1.0
 [v1.0.0...v1.1.0](https://github.com/Automattic/eslines/compare/v1.0.0...v1.1.0)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-filter-when-format": "tape tests/test-filter-when-format.js | faucet"
   },
   "dependencies": {
-    "jest-docblock": "20.0.3",
+    "jest-docblock": "26.0.0",
     "optionator": "0.9.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "optionator": "0.8.1"
   },
   "devDependencies": {
-    "tape": "4.6.0",
-    "faucet": "0.0.1",
     "eslint": "4.6.1",
     "eslint-config-wpcalypso": "1.0.0",
-    "eslint-plugin-wpcalypso": "4.0.0"
+    "eslint-plugin-wpcalypso": "4.0.0",
+    "faucet": "0.0.1",
+    "tape": "5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "jest-docblock": "20.0.3",
-    "optionator": "0.8.1"
+    "optionator": "0.9.1"
   },
   "devDependencies": {
     "babel-eslint": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "optionator": "0.8.1"
   },
   "devDependencies": {
+    "babel-eslint": "10.1.0",
     "eslint": "7.0.0",
-    "eslint-config-wpcalypso": "1.0.0",
-    "eslint-plugin-wpcalypso": "4.0.0",
+    "eslint-config-wpcalypso": "5.0.0",
+    "eslint-plugin-jsdoc": "25.4.1",
+    "eslint-plugin-wpcalypso": "4.1.0",
     "faucet": "0.0.1",
     "tape": "5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "optionator": "0.8.1"
   },
   "devDependencies": {
-    "eslint": "4.6.1",
+    "eslint": "7.0.0",
     "eslint-config-wpcalypso": "1.0.0",
     "eslint-plugin-wpcalypso": "4.0.0",
     "faucet": "0.0.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -94,7 +94,7 @@ module.exports = function( report, options ) {
 	process.env.ESLINES_DIFF = options.diff || 'remote';
 	let newReport = processors.reduce(
 		( accReport, processor ) => JSON.parse( processor( accReport ) ),
-		report
+		report,
 	);
 	delete process.env.ESLINES_DIFF;
 

--- a/src/lib/strip-warnings.js
+++ b/src/lib/strip-warnings.js
@@ -12,7 +12,7 @@ module.exports = function( results ) {
 					messages: filteredMessages,
 					errorCount: filteredMessages.length,
 					warningCount: 0,
-				} )
+				} ),
 			);
 		}
 	} );


### PR DESCRIPTION
This PR updates the dev and prod dependencies to the latest versions.

## Test

For dev dependencies:

- `npm run lint` and `npm run test` work as expected.

For prod dependencies:

- Clone a repo that uses eslines.
- Check that the lint job works as expected.
  - it doesn't fail
  - introduce an error and check that it fails
- Install eslines from this PR:
  - `npm pack` => generates a tgz
  - in the cloned repo: `npm install <path-to-tgz>`
- Check that lint job works as expected:
  - it doesn't fail if there are no errors
  - introduce an error and check that it fails
