### PR TITLE
Exclude ESLint 8 from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "tape": "5.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=6.0.0"
+    "eslint": "^6.0.0 || ^7.0.0"
   }
 }


### PR DESCRIPTION
ESLint 8 [does not allow](https://github.com/eslint/eslint/blob/e926b1735c77bf55abc1150b060a535a6c4e2778/package.json#L10) access to its formatters anymore, which [breaks](https://github.com/Automattic/eslines/blob/master/src/cli.js#L36) eslines:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/cli-engine/formatters/stylish' is not defined by "exports"
```

This PR restricts the `peerDependencies` not to include eslint@8.
